### PR TITLE
Define STS endpoint separately

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     data_endpoint: str = "127.0.0.1:9030"
     data_bucket_name: str = "slportal"
     data_secure: bool = False
+    data_sts_endpoint: str = "http://127.0.0.1:9030"
 
     # Database
     db_user: str

--- a/app/services/object_storage_client.py
+++ b/app/services/object_storage_client.py
@@ -19,7 +19,7 @@ class ObjectStorageClient:
             secure=settings.data_secure,
             credentials=WebIdentityProvider(
                 jwt_provider_func=self._fetch_access_token,
-                sts_endpoint=settings.data_endpoint,
+                sts_endpoint=settings.data_sts_endpoint,
             )
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def settings() -> Mock:
     settings.data_endpoint = "127.0.0.1:4242"
     settings.data_bucket_name = "testbucket"
     settings.data_secure = False
+    settings.data_sts_endpoint = "http://127.0.0.1:4242"
     return settings
 
 


### PR DESCRIPTION
The endpoint for the MinIO client must not have a scheme defined. However, passing a URL without a scheme to WebIdentityProvider makes it default to http. Therefore, we need to define the data endpoint and sts endpoint separately, the former without a scheme, the latter with a scheme.