### PR TITLE
Add teacher submission overview endpoint

### DIFF
--- a/app/core/models/assessment_result.py
+++ b/app/core/models/assessment_result.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ExerciseScore(BaseModel):
+    exercise_id: UUID
+    score: float | None
+
+
+class SubmissionResult(BaseModel):
+    assessment_submission_id: UUID
+    user_id: UUID
+    exercise_scores: list[ExerciseScore]
+    total_score: float | None
+    finished_at: datetime
+
+
+class AssessmentResult(BaseModel):
+    submissions: list[SubmissionResult]

--- a/app/core/models/assessment_submission.py
+++ b/app/core/models/assessment_submission.py
@@ -3,6 +3,8 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
+from app.core.models.exercise_submission import ExerciseSubmission
+
 
 class AssessmentSubmission(BaseModel):
     id: UUID = Field(default_factory=uuid4)
@@ -14,3 +16,5 @@ class AssessmentSubmission(BaseModel):
     score: float | None = None
     finished: bool = Field(default=False)
     finished_at: datetime | None = None
+
+    exercise_submissions: list[ExerciseSubmission] = Field(default_factory=list)

--- a/app/mappers/assessment_submission_mapper.py
+++ b/app/mappers/assessment_submission_mapper.py
@@ -2,6 +2,7 @@ import logging
 
 from app.core.models.assessment_submission import AssessmentSubmission
 from app.database.tables.assessment_submissions import DbAssessmentSubmission
+from app.mappers.exercise_submission_mapper import exercise_submission_to_domain
 
 logger = logging.getLogger(__name__)
 
@@ -12,10 +13,14 @@ def assessment_submission_to_domain(db_submission: DbAssessmentSubmission) -> As
         id=db_submission.id,
         created_at=db_submission.created_at,
         user_id=db_submission.user_id,
+        assessment_id=db_submission.assessment_id,
         score=db_submission.score,
         finished=db_submission.finished,
         finished_at=db_submission.finished_at,
-        assessment_id=db_submission.assessment_id
+        exercise_submissions=[
+            exercise_submission_to_domain(r)
+            for r in db_submission.exercise_submissions
+        ]
     )
     return assessment_submission
 

--- a/app/repositories/assessment_submissions.py
+++ b/app/repositories/assessment_submissions.py
@@ -73,6 +73,34 @@ def list_assessment_submissions(
     return [assessment_submission_to_domain(r) for r in result]
 
 
+def list_finished_assessment_submissions_for_assessment(
+        session: Session,
+        assessment_id: UUID,
+) -> list[AssessmentSubmission]:
+    logger.debug(
+        "Requesting assessment submissions for assessment %(assessment_id)s with session id %(session_id)s.",
+        {"assessment_id": assessment_id, "session_id": id(session)}
+    )
+
+    filter_conditions = {
+        DbAssessmentSubmission.assessment_id: assessment_id,
+        DbAssessmentSubmission.finished: True,
+    }
+
+    logger.debug(
+        "Used filter conditions: %(filter_conditions)s",
+        {"filter_conditions": filter_conditions}
+    )
+
+    result = get_all(
+        session=session,
+        _class=DbAssessmentSubmission,
+        filters=filter_conditions,
+        order_by=[DbAssessmentSubmission.created_at.desc()]
+    )
+    return [assessment_submission_to_domain(r) for r in result]
+
+
 def update_assessment_submission(session: Session, _id: UUID, **kwargs: Any) -> None:
     logger.debug(
         "Requesting update assessment submission %(_id)s with session id %(session_id)s.",

--- a/app/repositories/utils.py
+++ b/app/repositories/utils.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Iterator, Type, TypeAlias, TypeVar
 from uuid import UUID
 
-from sqlalchemy import ColumnElement, func, inspect, select, update
+from sqlalchemy import ColumnElement, func, inspect, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import InstrumentedAttribute, Session
 from sqlalchemy.orm.exc import UnmappedInstanceError
@@ -73,14 +73,23 @@ def get_all(
     return session.execute(query).scalars()
 
 
-def update_entry(session: Session, _class: Type[T], _id: UUID, commit: bool = True, **kwargs) -> None:
+def update_entry(session: Session, _class: Type[T], _id: UUID, commit: bool = True, **kwargs) -> T:
     logger.debug(
         "Using generic database request to update %(_id)s from %(_class)s with session id %(session_id)s.",
         {"_id": _id, "_class": _class.__name__, "session_id": id(session)}
     )
-    session.execute(update(_class).where(_class.id == _id).values(**kwargs))
+    db_obj = get_by_id(session, _class, _id)
+    if db_obj is None:
+        raise EntryNotFoundError(
+            f"Table '{_class.__tablename__}' has no entry with id '{_id}'."
+        )
+    for key, value in kwargs.items():
+        setattr(db_obj, key, value)
+
     if commit:
         session.commit()
+        session.refresh(db_obj)
+    return db_obj
 
 
 def upsert_entry(

--- a/app/rest/responses/assessment_results.py
+++ b/app/rest/responses/assessment_results.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ExerciseScoreResponse(BaseModel):
+    exercise_id: UUID
+    score: float | None
+
+
+class AssessmentSubmissionResultResponse(BaseModel):
+    assessment_submission_id: UUID
+    user_id: UUID
+    exercise_scores: list[ExerciseScoreResponse]
+    total_score: float | None
+    finished_at: datetime
+
+
+class AssessmentResultResponse(BaseModel):
+    submissions: list[AssessmentSubmissionResultResponse]

--- a/app/rest/routers/assessment_submissions.py
+++ b/app/rest/routers/assessment_submissions.py
@@ -12,10 +12,12 @@ from app.external_services.keycloak.auth_bearer import JWTBearer
 from app.rest.dependencies import get_current_user, require_roles
 from app.rest.filters.assessment_submissions import AssessmentSubmissionFilter
 from app.rest.requests.assessment_submissions import UpdateAssessmentSubmissionToFinishedRequest
+from app.rest.responses.assessment_results import AssessmentResultResponse
 from app.rest.responses.assessment_submissions import (
     CreateAssessmentSubmissionResponse, GetAssessmentSubmissionResponse,
     ListAssessmentSubmissionResponse, UpdateAssessmentSubmissionToFinishedResponse
 )
+from app.services.assessment_result_service import AssessmentResultService
 from app.services.assessment_submission_service import AssessmentSubmissionService
 
 logger = logging.getLogger(__name__)
@@ -63,6 +65,25 @@ async def get_assessment_submission(
         submission_id=submission_id
     )
     return submission
+
+
+@router.get(
+    "/assessments/{assessment_id}/results",
+    response_model=AssessmentResultResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[
+        Depends(require_roles([UserRole.TEST_SCORER]))
+    ],
+)
+async def get_assessment_results(
+        assessment_id: UUID,
+        assessment_result_service: Annotated[AssessmentResultService, Depends()],
+        db_session: Annotated[Session, Depends(get_db_session)]
+):
+    return assessment_result_service.get_assessment_result(
+        session=db_session,
+        assessment_id=assessment_id
+    )
 
 
 @router.get(

--- a/app/services/assessment_result_service.py
+++ b/app/services/assessment_result_service.py
@@ -1,0 +1,32 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.models.assessment_result import AssessmentResult, ExerciseScore, SubmissionResult
+from app.repositories.assessment_submissions import (
+    list_finished_assessment_submissions_for_assessment
+)
+
+
+class AssessmentResultService:
+    @staticmethod
+    def get_assessment_result(session: Session, assessment_id: UUID) -> AssessmentResult:
+        finished_assessment_submissions = list_finished_assessment_submissions_for_assessment(
+            session=session,
+            assessment_id=assessment_id,
+        )
+        submission_results = []
+        for assessment_submission in finished_assessment_submissions:
+            submission_results.append(
+                SubmissionResult(
+                    assessment_submission_id=assessment_submission.id,
+                    user_id=assessment_submission.user_id,
+                    exercise_scores=[
+                        ExerciseScore(exercise_id=exercise_submission.id, score=exercise_submission.score)
+                        for exercise_submission in assessment_submission.exercise_submissions
+                    ],
+                    total_score=assessment_submission.score,
+                    finished_at=assessment_submission.finished_at
+                )
+            )
+        return AssessmentResult(submissions=submission_results)

--- a/tests/data/models/assessment_results.py
+++ b/tests/data/models/assessment_results.py
@@ -1,0 +1,34 @@
+from app.core.models.assessment_result import AssessmentResult, ExerciseScore, SubmissionResult
+from tests.data.models.assessment_submissions import (
+    assessment_submission_1, assessment_submission_2
+)
+from tests.data.models.exercises import exercise_1, exercise_2
+from tests.data.models.users import test_taker_1
+
+exercise_score_1 = ExerciseScore(
+    exercise_id=exercise_1.id,
+    score=1,
+)
+exercise_score_2 = ExerciseScore(
+    exercise_id=exercise_2.id,
+    score=0,
+)
+
+submission_result_1 = SubmissionResult(
+    assessment_submission_id=assessment_submission_1.id,
+    user_id=test_taker_1.id,
+    exercise_scores=[exercise_score_1, exercise_score_2],
+    total_score=1,
+    finished_at=assessment_submission_1.finished_at
+)
+submission_result_2 = SubmissionResult(
+    assessment_submission_id=assessment_submission_2.id,
+    user_id=test_taker_1.id,
+    exercise_scores=[exercise_score_1, exercise_score_2],
+    total_score=1,
+    finished_at=assessment_submission_2.finished_at
+)
+
+assessment_result_1 = AssessmentResult(
+    submissions=[submission_result_1, submission_result_2]
+)

--- a/tests/data/models/assessment_submissions.py
+++ b/tests/data/models/assessment_submissions.py
@@ -9,14 +9,18 @@ assessment_submission_1 = AssessmentSubmission(
     id=uuid4(),
     assessment_id=assessment_1.id,
     user_id=test_taker_1.id,
-    score=None
+    score=1,
+    finished=True,
+    finished_at=assessment_1.created_at + timedelta(minutes=20)
 )
 
 assessment_submission_2 = AssessmentSubmission(
     id=uuid4(),
     assessment_id=assessment_2.id,
     user_id=test_taker_1.id,
-    score=None
+    score=0,
+    finished=True,
+    finished_at=assessment_2.created_at + timedelta(minutes=30)
 )
 
 assessment_submission_1_updated = AssessmentSubmission(

--- a/tests/database/repositories/test_assessment_submissions.py
+++ b/tests/database/repositories/test_assessment_submissions.py
@@ -10,7 +10,8 @@ from app.database.exceptions import EntryNotFoundError
 from app.database.tables.assessment_submissions import DbAssessmentSubmission
 from app.repositories.assessment_submissions import (
     add_assessment_submission, delete_assessment_submission, get_assessment_submission,
-    list_assessment_submissions, update_assessment_submission
+    list_assessment_submissions, list_finished_assessment_submissions_for_assessment,
+    update_assessment_submission
 )
 from tests.data.models.users import test_taker_1, test_taker_2
 from tests.database.data_inserts import insert_assessment, insert_assessment_submission
@@ -79,6 +80,22 @@ def test_list_multiple_assessment_submissions(db_session: Session) -> None:
 
     assert len(result) == 100
     assert table_count(db_session, DbAssessmentSubmission) == 100
+
+
+def test_list_finished_assessment_submissions_for_assessment(db_session: Session) -> None:
+    assessment_id = insert_assessment(session=db_session).get("id")
+    for n in range(10):
+        insert_assessment_submission(
+            session=db_session,
+            assessment_id=assessment_id,
+            finished_at=datetime(2000, 1, 1, 12, tzinfo=UTC) + timedelta(hours=n),
+            finished=True if n % 2 == 0 else False
+        )
+
+    result = list_finished_assessment_submissions_for_assessment(session=db_session, assessment_id=assessment_id)
+
+    assert len(result) == 5
+    assert table_count(db_session, DbAssessmentSubmission) == 10
 
 
 def test_list_assessment_submissions_with_filter(db_session: Session) -> None:

--- a/tests/database/repositories/test_assessment_submissions.py
+++ b/tests/database/repositories/test_assessment_submissions.py
@@ -216,6 +216,13 @@ def test_update_assessment_submission(db_session: Session) -> None:
     assert table_count(db_session, DbAssessmentSubmission) == 1
 
 
+def test_update_non_existing_assessment_submission(db_session: Session) -> None:
+    with pytest.raises(EntryNotFoundError, match=r"has no entry with id"):
+        update_assessment_submission(session=db_session, _id=uuid4(), **{"score": 1})
+
+    assert table_count(db_session, DbAssessmentSubmission) == 0
+
+
 def test_delete_assessment_submission(db_session: Session) -> None:
     assessment = insert_assessment(session=db_session)
     assessment_submission = insert_assessment_submission(

--- a/tests/database/repositories/test_exercise_submissions.py
+++ b/tests/database/repositories/test_exercise_submissions.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 from app.core.models.exercise_submission import ExerciseSubmission
 from app.core.models.multiple_choice_answer import MultipleChoiceAnswer
 from app.database.exceptions import EntryNotFoundError
-from app.database.tables.assessment_submissions import DbAssessmentSubmission
 from app.database.tables.exercise_submissions import DbExerciseSubmission
 from app.repositories.exercise_submissions import (
     add_exercise_submission, delete_exercise_submission, get_exercise_submission,

--- a/tests/rest/conftest.py
+++ b/tests/rest/conftest.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from pydantic_settings import BaseSettings
 
 from app.core.models.assessment import Assessment
+from app.core.models.assessment_result import AssessmentResult
 from app.core.models.assessment_submission import AssessmentSubmission
 from app.core.models.choice import Choice
 from app.core.models.exercise import Exercise
@@ -20,6 +21,7 @@ from app.external_services.minio.client import ObjectStorageClient
 from app.main import app
 from app.rest.dependencies import get_current_user
 from app.rest.requests.assessment_submissions import UpdateAssessmentSubmissionToFinishedRequest
+from app.services.assessment_result_service import AssessmentResultService
 from app.services.assessment_service import AssessmentService
 from app.services.assessment_submission_service import AssessmentSubmissionService
 from app.services.choice_service import ChoiceService
@@ -35,6 +37,7 @@ from app.services.multiple_choice_service import MultipleChoiceService
 from app.services.primer_service import PrimerService
 from app.services.task_service import TaskService
 from app.settings import get_settings
+from tests.data.models.assessment_results import assessment_result_1
 from tests.data.models.assessment_submissions import (
     assessment_submission_1, assessment_submission_1_updated, assessment_submission_2
 )
@@ -68,6 +71,9 @@ def app_dependency_overrides_data() -> FastAPI:
         get_by_id_return=assessment_submission_1,
         update_submission=assessment_submission_1_updated,
         list_return=[assessment_submission_1, assessment_submission_2]
+    )
+    app.dependency_overrides[AssessmentResultService] = _get_override_assessment_result_service(
+        get_by_id_return=assessment_result_1
     )
     app.dependency_overrides[ChoiceService] = _get_override_choice_service(
         create_return=choice_1,
@@ -206,6 +212,17 @@ def _get_override_assessment_submission_service(
         return assessment_submission_service
 
     return override_assessment_submission_service
+
+
+def _get_override_assessment_result_service(
+        get_by_id_return: AssessmentResult | None = None,
+) -> Callable:
+    async def override_assessment_result_service() -> Mock:
+        assessment_result_service = Mock()
+        assessment_result_service.get_assessment_result.return_value = get_by_id_return
+        return assessment_result_service
+
+    return override_assessment_result_service
 
 
 def _get_override_choice_service(

--- a/tests/rest/routes/test_assessment_submissions_route.py
+++ b/tests/rest/routes/test_assessment_submissions_route.py
@@ -3,9 +3,11 @@ from unittest.mock import ANY
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from tests.data.models.assessment_results import exercise_score_1, exercise_score_2
 from tests.data.models.assessment_submissions import (
     assessment_submission_1, assessment_submission_2
 )
+from tests.data.models.assessments import assessment_1
 from tests.data.models.users import test_scorer_1, test_taker_1, test_taker_2
 
 
@@ -27,11 +29,53 @@ def test_get_assessment_submission(test_client: TestClient) -> None:
         "id": str(submission_id),
         "user_id": str(test_taker_1.id),
         "assessment_id": str(assessment_submission_1.assessment_id),
-        "score": None,
-        "finished": False,
-        "finished_at": None
+        "score": 1.0,
+        "finished": True,
+        "finished_at": ANY,
     }
 
+
+def test_get_assessment_result(test_client_with_scorer_role: TestClient) -> None:
+    assessment_id = assessment_1.id
+
+    response = test_client_with_scorer_role.get(f"/assessments/{assessment_id}/results",).json()
+
+    assert response == {
+        "submissions": [
+            {
+                "assessment_submission_id": str(assessment_submission_1.id),
+                "exercise_scores": [
+                    {
+                        "exercise_id": str(exercise_score_1.exercise_id),
+                        "score": exercise_score_1.score
+                    },
+                    {
+                        "exercise_id": str(exercise_score_2.exercise_id),
+                        "score": exercise_score_2.score
+                    }
+                ],
+                "finished_at": assessment_submission_1.finished_at.isoformat().replace("+00:00", "Z"),
+                "total_score": 1.0,
+                "user_id": str(test_taker_1.id)
+            },
+            {
+                "assessment_submission_id": str(assessment_submission_2.id),
+                "exercise_scores": [
+                    {
+                        "exercise_id": str(exercise_score_1.exercise_id),
+                        "score": exercise_score_1.score
+                    },
+                    {
+                        "exercise_id": str(exercise_score_2.exercise_id),
+                        "score": exercise_score_2.score
+                    }
+                ],
+                "finished_at": assessment_submission_2.finished_at.isoformat().replace("+00:00", "Z"),
+                "total_score": 1.0,
+                "user_id": str(test_taker_1.id)
+            }
+        ]
+    }
 
 def test_list_assessment_submissions(test_client: TestClient) -> None:
     response = test_client.get("/assessment_submissions/").json()

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -7,6 +7,7 @@ from app.core.models.media_types import MediaType
 from app.core.models.minio_location import MinioLocation
 from app.core.models.multimedia_file import MultimediaFile
 from app.external_services.minio.client import ObjectStorageClient
+from app.services.assessment_result_service import AssessmentResultService
 from app.services.assessment_service import AssessmentService
 from app.services.assessment_submission_service import AssessmentSubmissionService
 from app.services.choice_service import ChoiceService
@@ -108,6 +109,11 @@ def exercise_submission_service(exercise_service: ExerciseService) -> ExerciseSu
 @pytest.fixture
 def assessment_submission_service() -> AssessmentSubmissionService:
     return AssessmentSubmissionService()
+
+
+@pytest.fixture
+def assessment_result_service() -> AssessmentResultService:
+    return AssessmentResultService()
 
 
 @pytest.fixture

--- a/tests/services/test_assessment_result_service.py
+++ b/tests/services/test_assessment_result_service.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock, Mock, patch
+
+from app.core.models.assessment_result import AssessmentResult, SubmissionResult
+from app.services import assessment_result_service as assessment_result_service_module
+from app.services.assessment_result_service import (
+    AssessmentResultService, list_finished_assessment_submissions_for_assessment
+)
+from tests.data.models.assessment_submissions import (
+    assessment_submission_1, assessment_submission_2
+)
+from tests.data.models.assessments import assessment_1
+
+
+@patch.object(
+    assessment_result_service_module, list_finished_assessment_submissions_for_assessment.__name__,
+    return_value=[assessment_submission_1, assessment_submission_2]
+)
+def test_get_assessment_result(
+        mocked_list_finished_submission: MagicMock,
+        assessment_result_service: AssessmentResultService
+) -> None:
+    mocked_session = Mock()
+
+    assessment_result = assessment_result_service.get_assessment_result(mocked_session, assessment_1.id)
+
+    # TODO: add exercise scores in test data (yet empty)
+    assert assessment_result == AssessmentResult(
+        submissions=[
+            SubmissionResult(
+                assessment_submission_id=assessment_submission_1.id,
+                user_id=assessment_submission_1.user_id,
+                exercise_scores=[],
+                total_score=1.0,
+                finished_at=assessment_submission_1.finished_at
+            ),
+            SubmissionResult(
+                assessment_submission_id=assessment_submission_2.id,
+                user_id=assessment_submission_2.user_id,
+                exercise_scores=[],
+                total_score=0.0,
+                finished_at=assessment_submission_2.finished_at
+            )
+        ]
+    )
+    mocked_list_finished_submission.assert_called_once_with(session=mocked_session, assessment_id=assessment_1.id)


### PR DESCRIPTION
## Summary

- Add `GET /assessments/{assessment_id}/results` endpoint restricted to users with the `test-scorer` role
- Returns all finished submissions for an assessment with per-exercise scores and total score
- New domain models in `app/core/models/assessment_results.py` and response models in `app/rest/responses/assessment_results.py`
- New repository function `list_finished_assessment_submissions_for_assessment` to fetch finished submissions by assessment