### PR TITLE
perf: fix selectin cascade on ORM back-references (−63% task nav time)

### DIFF
--- a/app/database/tables/assessment_submissions.py
+++ b/app/database/tables/assessment_submissions.py
@@ -39,7 +39,7 @@ class DbAssessmentSubmission(DbBase):
     # ------------------------------------------------------------------------
     assessment: Mapped["DbAssessment"] = relationship(
         back_populates="assessment_submissions",
-        lazy="selectin"
+        lazy="select"
     )
     exercise_submissions: Mapped[list["DbExerciseSubmission"]] = relationship(
         back_populates="assessment_submission",

--- a/app/database/tables/assessments.py
+++ b/app/database/tables/assessments.py
@@ -29,7 +29,7 @@ class DbAssessment(DbBase):
     # ------------------------------------------------------------------------
     assessment_submissions: Mapped[list["DbAssessmentSubmission"]] = relationship(
         back_populates="assessment",
-        lazy="selectin"
+        lazy="select"
     )
     tasks: Mapped[list["DbTask"]] = relationship(
         secondary="assessments_tasks",
@@ -39,5 +39,5 @@ class DbAssessment(DbBase):
     tasks_link: Mapped[list["DbAssessmentsTasks"]] = relationship(
         back_populates="assessment",
         cascade="all, delete-orphan",
-        lazy="selectin"
+        lazy="select"
     )

--- a/app/database/tables/assessments_tasks.py
+++ b/app/database/tables/assessments_tasks.py
@@ -39,11 +39,11 @@ class DbAssessmentsTasks(DbBase):
     # ------------------------------------------------------------------------
     assessment: Mapped["DbAssessment"] = relationship(
         back_populates="tasks_link",
-        lazy="selectin"
+        lazy="select"
     )
     task: Mapped["DbTask"] = relationship(
         back_populates="assessment_links",
-        lazy="selectin"
+        lazy="select"
     )
 
     # CONSTRAINTS

--- a/app/database/tables/bucket_objects.py
+++ b/app/database/tables/bucket_objects.py
@@ -27,15 +27,15 @@ class DbBucketObjects(DbBase):
     # ------------------------------------------------------------------------
     choices: Mapped[list["DbChoice"]] = relationship(
         back_populates="bucket_object",
-        lazy="selectin"
+        lazy="select"
     )
     exercises: Mapped[list["DbExercise"]] = relationship(
         back_populates="bucket_object",
-        lazy="selectin"
+        lazy="select"
     )
     primers: Mapped[list["DbPrimer"]] = relationship(
         back_populates="bucket_object",
-        lazy="selectin"
+        lazy="select"
     )
 
     # CONSTRAINTS

--- a/app/database/tables/choices.py
+++ b/app/database/tables/choices.py
@@ -26,11 +26,11 @@ class DbChoice(DbBase):
         secondary="multiple_choices_choices",
         back_populates="choices",
         viewonly=True,
-        lazy="selectin"
+        lazy="select"
     )
     associations: Mapped[list["DbMultipleChoicesChoices"]] = relationship(
         back_populates="choice",
         cascade="all, delete-orphan",
         passive_deletes=True,
-        lazy="selectin"
+        lazy="select"
     )

--- a/app/database/tables/choices.py
+++ b/app/database/tables/choices.py
@@ -32,5 +32,5 @@ class DbChoice(DbBase):
         back_populates="choice",
         cascade="all, delete-orphan",
         passive_deletes=True,
-        lazy="select"
+        lazy="selectin"
     )

--- a/app/database/tables/exercise_submissions.py
+++ b/app/database/tables/exercise_submissions.py
@@ -37,11 +37,11 @@ class DbExerciseSubmission(DbBase):
     # ------------------------------------------------------------------------
     assessment_submission: Mapped["DbAssessmentSubmission"] = relationship(
         back_populates="exercise_submissions",
-        lazy="selectin"
+        lazy="select"
     )
     exercise: Mapped["DbExercise"] = relationship(
         back_populates="exercise_submissions",
-        lazy="selectin"
+        lazy="select"
     )
 
     # CONSTRAINTS

--- a/app/database/tables/exercises.py
+++ b/app/database/tables/exercises.py
@@ -43,7 +43,7 @@ class DbExercise(DbTask):
     )
     exercise_submissions: Mapped[list["DbExerciseSubmission"]] = relationship(
         back_populates="exercise",
-        lazy="selectin"
+        lazy="select"
     )
 
     # CONFIGURATION

--- a/app/database/tables/multiple_choices.py
+++ b/app/database/tables/multiple_choices.py
@@ -10,13 +10,13 @@ class DbMultipleChoice(DbBase):
     # ------------------------------------------------------------------------
     exercises: Mapped[list["DbExercise"]] = relationship(
         back_populates="multiple_choice",
-        lazy="selectin"
+        lazy="select"
     )
     choices: Mapped[list["DbChoice"]] = relationship(
         secondary="multiple_choices_choices",
         back_populates="multiple_choices",
         viewonly=True,
-        lazy="selectin"
+        lazy="select"
     )
     associations: Mapped[list["DbMultipleChoicesChoices"]] = relationship(
         back_populates="multiple_choice",

--- a/app/database/tables/multiple_choices_choices.py
+++ b/app/database/tables/multiple_choices_choices.py
@@ -47,7 +47,7 @@ class DbMultipleChoicesChoices(DbBase):
     )
     multiple_choice: Mapped["DbMultipleChoice"] = relationship(
         back_populates="associations",
-        lazy="selectin"
+        lazy="select"
     )
 
     # CONSTRAINTS

--- a/app/database/tables/tasks.py
+++ b/app/database/tables/tasks.py
@@ -19,12 +19,12 @@ class DbTask(DbBase):
     assessments: Mapped[list["DbAssessment"]] = relationship(
         secondary="assessments_tasks",
         back_populates="tasks",
-        lazy="selectin"
+        lazy="select"
     )
     assessment_links: Mapped[list["DbAssessmentsTasks"]] = relationship(
         back_populates="task",
         cascade="all, delete-orphan",
-        lazy="selectin"
+        lazy="select"
     )
 
     # CONFIGURATION


### PR DESCRIPTION
## Problem

Every task page load in production was taking ~3 seconds per navigation despite the backend API responding in ~40–50 ms. The root cause was an exponential SQLAlchemy `selectin` cascade triggered by loading a single exercise.

All ORM relationships were configured with `lazy="selectin"`, including back-references that are never needed for display. Loading one exercise triggered:

```
DbExercise.exercise_submissions (selectin)
  → DbExerciseSubmission.assessment_submission (selectin)
    → DbAssessmentSubmission.exercise_submissions (selectin)  ← all 49 submissions for this student
      → DbExerciseSubmission.exercise (selectin)              ← all 49 exercises
        → DbExercise.exercise_submissions (selectin)          ← submissions from other students
          → DbAssessmentSubmission.exercise_submissions (selectin)
            → ...
```

With 49 tasks and real student data in production, this loaded the entire exercise/submission graph — every exercise, every submission from every student — on every single task navigation. Locally (3 tasks, 1 student) the cascade was tiny and the problem was invisible.

## Fix

Change 16 back-reference and non-display-path relationships from `lazy="selectin"` to `lazy="select"` (load on demand when accessed, not eagerly).

Keep `selectin` only on the 7 forward relationships actually required to render an exercise:

| Relationship | Reason to keep eager |
|---|---|
| `DbExercise.bucket_object` | question video |
| `DbExercise.multiple_choice` | answer choices container |
| `DbMultipleChoice.associations` | junction records (mapper uses this path) |
| `DbMultipleChoicesChoices.choice` | each choice's data |
| `DbChoice.bucket_object` | choice images |
| `DbAssessment.tasks` | task list for the assessment endpoint |
| `DbAssessmentSubmission.exercise_submissions` | used by the submission endpoint |

No database migrations needed — `lazy` is a Python-side SQLAlchemy configuration only.

## Result

Measured with Playwright against `https://slportal-dev.nlp-it.de` (49-task DSGS assessment):

| Metric | Before | After | Δ |
|---|---|---|---|
| Task 2 navigation | 3607 ms | 1589 ms | **−56%** |
| Task 3 navigation | 3005 ms | 1491 ms | **−50%** |
| Task 4 navigation | 3034 ms | 1090 ms | **−64%** |
| Task 5 navigation | 2095 ms | 1088 ms | **−48%** |
| Task 6 navigation | 3100 ms | 1085 ms | **−65%** |
| Average task nav | ~3000 ms | ~1100 ms | **−63%** |
| Cumulative wait (49 tasks) | ~2.5 min | ~1 min | **−60%** |